### PR TITLE
added check that event.data.pluginMessage is a stringified figma-jsonrpc objects

### DIFF
--- a/rpc.js
+++ b/rpc.js
@@ -44,18 +44,23 @@ function sendError(id, error) {
 }
 
 function handleRaw(data) {
-  try {
-    data.split("\n").forEach(bunch => {
-      bunch = bunch.trim();
-      if (!bunch) {
-        return;
-      }
-      const json = JSON.parse(bunch);
-      handleRpc(json);
-    });
-  } catch (err) {
-    console.error(err);
-    console.error(data);
+  if (
+    (typeof data === "string" || data instanceof String) &&
+    data.includes('"jsonrpc":"2.0"')
+  ) {
+    try {
+      data.split("\n").forEach(bunch => {
+        bunch = bunch.trim();
+        if (!bunch) {
+          return;
+        }
+        const json = JSON.parse(bunch);
+        handleRpc(json);
+      });
+    } catch (err) {
+      console.error(err);
+      console.error(data);
+    }
   }
 }
 


### PR DESCRIPTION
son-rpc is assuming all postMessages are stringified figma-jsonrpc objects which is causing errors when postMessage is used

related to this bug: https://github.com/Lona/figma-jsonrpc/issues/1